### PR TITLE
feat(otlp): add custom headers support for OTLP exporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,7 @@ catch (Exception ex)
 | `ServiceVersion` | `string` | `"1.0.0"` | Service version |
 | `OtlpEndpoint` | `string` | `null` | OTLP collector endpoint (e.g., `http://localhost:4317`) |
 | `UseOtlpHttp` | `bool` | `false` | Use HTTP/protobuf instead of gRPC |
+| `OtlpHeaders` | `IDictionary<string, string>` | empty | Custom headers for OTLP requests (auth, API keys) |
 | `EnableConsoleExporter` | `bool` | `false` | Output telemetry to console (for debugging) |
 | `EnableTracing` | `bool` | `true` | Enable distributed tracing |
 | `EnableMetrics` | `bool` | `true` | Enable metrics collection |
@@ -254,6 +255,23 @@ VsixTelemetry.Initialize(new TelemetryConfiguration
     },
     ExceptionFilter = ex => !(ex is OperationCanceledException)  // Ignore cancellations
 });
+```
+
+### Example: Using Custom Headers (Honeycomb, etc.)
+
+```csharp
+var config = new TelemetryConfiguration
+{
+    ServiceName = "MyExtension",
+    OtlpEndpoint = "https://api.honeycomb.io:443",
+    UseOtlpHttp = true
+};
+
+// Add authentication headers
+config.OtlpHeaders["x-honeycomb-team"] = "your-api-key";
+config.OtlpHeaders["x-honeycomb-dataset"] = "your-dataset";
+
+VsixTelemetry.Initialize(config);
 ```
 
 ---

--- a/src/CodingWithCalvin.Otel4Vsix/TelemetryConfiguration.cs
+++ b/src/CodingWithCalvin.Otel4Vsix/TelemetryConfiguration.cs
@@ -41,6 +41,21 @@ namespace Otel4Vsix
         public bool UseOtlpHttp { get; set; }
 
         /// <summary>
+        /// Gets custom headers to include in OTLP export requests.
+        /// </summary>
+        /// <remarks>
+        /// Use this to add authentication headers (API keys, bearer tokens) or other custom headers
+        /// required by your telemetry backend.
+        /// <example>
+        /// <code>
+        /// config.OtlpHeaders["x-api-key"] = "your-api-key";
+        /// config.OtlpHeaders["Authorization"] = "Bearer your-token";
+        /// </code>
+        /// </example>
+        /// </remarks>
+        public IDictionary<string, string> OtlpHeaders { get; } = new Dictionary<string, string>();
+
+        /// <summary>
         /// Gets or sets a value indicating whether the console exporter is enabled.
         /// </summary>
         /// <remarks>


### PR DESCRIPTION
## Summary

- Added `OtlpHeaders` dictionary property to `TelemetryConfiguration` for custom OTLP headers
- Created shared `ConfigureOtlpExporter()` method to reduce code duplication
- Headers are applied to all OTLP exporters (traces, metrics, logs)
- Updated README with documentation and Honeycomb example

## Usage

```csharp
var config = new TelemetryConfiguration
{
    ServiceName = "MyExtension",
    OtlpEndpoint = "https://api.honeycomb.io:443",
    UseOtlpHttp = true
};

config.OtlpHeaders["x-honeycomb-team"] = "your-api-key";
config.OtlpHeaders["x-honeycomb-dataset"] = "your-dataset";

VsixTelemetry.Initialize(config);
```

## Test Plan

- [ ] Build succeeds
- [ ] Headers are correctly formatted as `key1=value1,key2=value2` for OTLP exporter